### PR TITLE
fix: 버튼 컴포넌트의 variant 타입 solid -> primary 변경 클래스 스타일 전역변수로 수정

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 
-type Variant = "solid" | "outline" | "disabled";
+type Variant = "primary" | "outline" | "disabled";
 type Size = "sm" | "md" | "lg";
 
 interface ButtonProps {
@@ -12,9 +12,9 @@ interface ButtonProps {
 }
 
 const variantClasses: Record<Variant, string> = {
-  solid: "bg-[#ea3c12] text-white cursor-pointer",
-  outline: "border text-[#ea3c12] cursor-pointer",
-  disabled: "bg-[#a4a1aa] text-white cursor-not-allowed",
+  primary: "bg-red-50 text-white cursor-pointer",
+  outline: "border border-red-50 text-red-50 cursor-pointer",
+  disabled: "bg-gray-40 text-white cursor-not-allowed",
 };
 const sizeClasses: Record<Size, string> = {
   sm: "px-3 py-2 text-xs/[16px] font-normal ",
@@ -24,7 +24,7 @@ const sizeClasses: Record<Size, string> = {
 
 export default function Button({
   children,
-  variant = "solid",
+  variant = "primary",
   size = "lg",
   disabled,
   ...rest


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [ x ] 코드 개선 (Refactoring)
- [ x ] 스타일 변경 (UI/UX)

## 🔍 변경 사항
기존에 Button이 받던 주요버튼을 의미하는 variant 'solid' 를 -> 'primary'로 변경하였습니다.
전역 스타일링 변수를 참조해 수정했습니다.

## 📸 스크린샷


## 🛠️ 테스트 방법

1.  solid 에서 primary로만 변경했습니다.
2. 버튼을 여러개 선언해서 사용해보세요!


## 💡 추가 정보


## 🙏 리뷰어에게
