### PR TITLE
✨ [Feat] 로그인 및 회원가입 시 토큰을 로컬 스토리지에 저장하는 기능 추가

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -57,6 +57,7 @@ export default function LoginPage() {
 
       //정상 반환의 경우 개인 페이지로 이동합니다.
       const result = await response.json();
+      localStorage.setItem("token", result.item.token);
       router.push(result.item.user.item.id);
     } catch (err: any) {
       //로그인이 실패했음을 알리는 모달을 엽니다.

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -65,6 +65,7 @@ export default function LoginPage() {
       }
 
       const result = await response.json();
+      localStorage.setItem("token", result.item.token);
 
       setIsOpenAlert(true);
       setAlertType("signup"); //회원가입이 성공했음을 알리는 모달타입으로 변경


### PR DESCRIPTION
# 🚀 Pull Request

## 🚧 관련 이슈
#46 해당 이슈에 댓글로 쿠키세팅관련 조사결과를 간단히 작성했습니다 참고해주세요

## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [x] 기능 추가 (Feature)

## 🔍 변경 사항
로그인/회원가입 후 accessToken을 로컬스토리지에 'token'으로 저장하였습니다.

## 📸 스크린샷
<img width="2032" alt="스크린샷 2025-05-02 오후 5 37 11" src="https://github.com/user-attachments/assets/65a77a40-beda-487d-8569-7b1746db39e6" />

## 🛠️ 테스트 방법
1. 로그인이나 회원가입을 진행한 후 브라우저의 애플리케이션 -> 로컬스토리지에서 확인 할 수 있습니다.


## 💡 추가 정보
#46 이슈의 댓글을 간단히 읽어보고 추후 논의 예정입니다.

## 🙏 리뷰어에게
간단한 변경사항입니다.
