### PR TITLE
🐛 [Fix]  가게상세정보페이지와 공고등록페이지 연결

### DIFF
--- a/src/app/(main)/shops/[shopId]/page.tsx
+++ b/src/app/(main)/shops/[shopId]/page.tsx
@@ -195,7 +195,7 @@ export default function ShopDetailPage() {
         `}</style>
 
         <div className="px-6 py-10">
-          <h2 className="text-[24px] font-bold mb-6">내가 등록한 공고</h2>
+          {/* 제목을 제거하여 중복을 방지합니다 */}
           {shopIdForNotices && <ShopNotices shopId={shopIdForNotices} />}
         </div>
       </section>

--- a/src/components/ShopCard/ShopAction.tsx
+++ b/src/components/ShopCard/ShopAction.tsx
@@ -63,7 +63,7 @@ export default function ShopAction({ shopId }: ShopActionProps) {
       </button>
       <button
         className={`${buttonStyles.registerButton} bg-red-50 text-white rounded-md text-center`}
-        onClick={() => router.push(`/shops/${shopId}/notices/new`)}
+        onClick={() => router.push(`/shops/${shopId}/register-notice`)}
       >
         공고 등록하기
       </button>


### PR DESCRIPTION
# 🚀 Pull Request


## 📝 PR 유형
<!-- 해당하는 유형에 'x'로 체크해주세요 -->
- [X] 기능 추가 (Feature)
- [X] 버그 수정 (Bug Fix)

## 🔍 변경 사항
  - ShopAction.tsx 파일의 공고 등록하기 버튼을 클릭했을 때 이동하는 경로를 변경
  - 공고 미등록 시, 공고등록하기 타이틀 위에 글자 중복해서 나오는 부분 수정

